### PR TITLE
replace LazyLock with lazy_static that works with Rust 1.63.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,6 +706,7 @@ dependencies = [
  "fd-lock",
  "gethostname",
  "itertools",
+ "lazy_static",
  "nu-ansi-term",
  "pretty_assertions",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ crossbeam = { version = "0.8.2", optional = true }
 crossterm = { version = "0.28.1", features = ["serde"] }
 fd-lock = "4.0.2"
 itertools = "0.13.0"
+lazy_static = "1.5.0"
 nu-ansi-term = "0.50.0"
 regex = "1.11"
 rusqlite = { version = "0.31.0", optional = true }

--- a/src/menu/menu_functions.rs
+++ b/src/menu/menu_functions.rs
@@ -1,16 +1,16 @@
 //! Collection of common functions that can be used to create menus
 use nu_ansi_term::{ansi::RESET, Style};
 use regex::Regex;
-use std::sync::LazyLock;
+use lazy_static::lazy_static;
 use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{Editor, Suggestion, UndoBehavior};
 
-/// Matches ANSI escapes. Stolen from https://github.com/dbkaplun/parse-ansi, which got it from
-/// https://github.com/nodejs/node/blob/641d4a4159aaa96eece8356e03ec6c7248ae3e73/lib/internal/readline.js#L9
-static ANSI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"[\x1b\x9b]\[[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]").unwrap()
-});
+lazy_static! {
+    /// Matches ANSI escapes. Stolen from https://github.com/dbkaplun/parse-ansi, which got it from
+    /// https://github.com/nodejs/node/blob/641d4a4159aaa96eece8356e03ec6c7248ae3e73/lib/internal/readline.js#L9
+    static ref ANSI_REGEX: Regex = Regex::new(r"[\x1b\x9b]\[[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]").unwrap();
+}
 
 /// Index result obtained from parsing a string with an index marker
 /// For example, the next string:


### PR DESCRIPTION
@ysthakur 

this fixes
```bash
warning: current MSRV (Minimum Supported Rust Version) is `1.63.0` but this item is stable since `1.80.0`
   |
11 | static ANSI_REGEX: LazyLock<Regex> = LazyLock::new(|| {
   |                                      ^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incompatible_msrv
   = note: `#[warn(clippy::incompatible_msrv)]` on by default
   ```